### PR TITLE
Default `To` address if X-Original-To is not given

### DIFF
--- a/src/slc/mailrouter/utils.py
+++ b/src/slc/mailrouter/utils.py
@@ -80,7 +80,8 @@ class BaseMailRouter(object):
 
         sender_from = email.Utils.parseaddr(sender_from)[1]
         sender_return_path = email.Utils.parseaddr(sender_return_path)[1]
-        recipient = email.Utils.parseaddr(msg.get('X-Original-To'))[1]
+        recipient = email.Utils.parseaddr(
+            msg.get('X-Original-To', msg.get('To') ))[1]
 
         if not recipient:
             logger.info('BaseMailRouter could not identify a recipient.' +


### PR DESCRIPTION
GMAIL by default does not send the 'X-Original-To' header in an email for the initial address. As a result, the mail to the server won't process since there is no X-Original-To address to get the recipient email from. Therefore, I've added `msg.get('To')` as a fallback method to get the recipient address.